### PR TITLE
fix: resolve timeout errors in API routes

### DIFF
--- a/src/app/api/concat/route.ts
+++ b/src/app/api/concat/route.ts
@@ -28,23 +28,59 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error generating concatenating audio:', error.response.data);
-      if (error.response.status === 402) {
-        return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
-          status: 402,
+      console.error('Error generating concatenating audio:', error);
+      
+      // Handle different types of errors
+      if (error.response) {
+        // Axios error with response
+        console.error('Response error:', JSON.stringify(error.response.data));
+        
+        if (error.response.status === 402) {
+          return new NextResponse(JSON.stringify({ 
+            error: error.response.data?.detail || 'Payment required' 
+          }), {
+            status: 402,
+            headers: {
+              'Content-Type': 'application/json',
+              ...corsHeaders
+            }
+          });
+        }
+        
+        return new NextResponse(JSON.stringify({ 
+          error: 'API Error: ' + (error.response.data?.detail || error.response.statusText || 'Unknown error')
+        }), {
+          status: error.response.status || 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else if (error.request) {
+        // Axios error without response (network error, timeout, etc.)
+        console.error('Network error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Network error: Unable to connect to Suno API. Please check your internet connection and try again.' 
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else {
+        // Other types of errors (timeout, etc.)
+        console.error('Other error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Internal error: ' + (error.message || 'Unknown error occurred') 
+        }), {
+          status: 500,
           headers: {
             'Content-Type': 'application/json',
             ...corsHeaders
           }
         });
       }
-      return new NextResponse(JSON.stringify({ error: 'Internal server error' }), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
     }
   } else {
     return new NextResponse('Method Not Allowed', {

--- a/src/app/api/extend_audio/route.ts
+++ b/src/app/api/extend_audio/route.ts
@@ -32,23 +32,59 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error extend audio:', JSON.stringify(error.response.data));
-      if (error.response.status === 402) {
-        return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
-          status: 402,
+      console.error('Error extend audio:', error);
+      
+      // Handle different types of errors
+      if (error.response) {
+        // Axios error with response
+        console.error('Response error:', JSON.stringify(error.response.data));
+        
+        if (error.response.status === 402) {
+          return new NextResponse(JSON.stringify({ 
+            error: error.response.data?.detail || 'Payment required' 
+          }), {
+            status: 402,
+            headers: {
+              'Content-Type': 'application/json',
+              ...corsHeaders
+            }
+          });
+        }
+        
+        return new NextResponse(JSON.stringify({ 
+          error: 'API Error: ' + (error.response.data?.detail || error.response.statusText || 'Unknown error')
+        }), {
+          status: error.response.status || 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else if (error.request) {
+        // Axios error without response (network error, timeout, etc.)
+        console.error('Network error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Network error: Unable to connect to Suno API. Please check your internet connection and try again.' 
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else {
+        // Other types of errors (timeout, etc.)
+        console.error('Other error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Internal error: ' + (error.message || 'Unknown error occurred') 
+        }), {
+          status: 500,
           headers: {
             'Content-Type': 'application/json',
             ...corsHeaders
           }
         });
       }
-      return new NextResponse(JSON.stringify({ error: 'Internal server error: ' + JSON.stringify(error.response.data.detail) }), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
     }
   } else {
     return new NextResponse('Method Not Allowed', {

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -26,23 +26,59 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error generating custom audio:', JSON.stringify(error.response.data));
-      if (error.response.status === 402) {
-        return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
-          status: 402,
+      console.error('Error generating audio:', error);
+      
+      // Handle different types of errors
+      if (error.response) {
+        // Axios error with response
+        console.error('Response error:', JSON.stringify(error.response.data));
+        
+        if (error.response.status === 402) {
+          return new NextResponse(JSON.stringify({ 
+            error: error.response.data?.detail || 'Payment required' 
+          }), {
+            status: 402,
+            headers: {
+              'Content-Type': 'application/json',
+              ...corsHeaders
+            }
+          });
+        }
+        
+        return new NextResponse(JSON.stringify({ 
+          error: 'API Error: ' + (error.response.data?.detail || error.response.statusText || 'Unknown error')
+        }), {
+          status: error.response.status || 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else if (error.request) {
+        // Axios error without response (network error, timeout, etc.)
+        console.error('Network error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Network error: Unable to connect to Suno API. Please check your internet connection and try again.' 
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else {
+        // Other types of errors (timeout, etc.)
+        console.error('Other error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Internal error: ' + (error.message || 'Unknown error occurred') 
+        }), {
+          status: 500,
           headers: {
             'Content-Type': 'application/json',
             ...corsHeaders
           }
         });
       }
-      return new NextResponse(JSON.stringify({ error: 'Internal server error: ' + JSON.stringify(error.response.data.detail) }), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
     }
   } else {
     return new NextResponse('Method Not Allowed', {

--- a/src/app/api/generate_lyrics/route.ts
+++ b/src/app/api/generate_lyrics/route.ts
@@ -21,23 +21,59 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error generating lyrics:', JSON.stringify(error.response.data));
-      if (error.response.status === 402) {
-        return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
-          status: 402,
+      console.error('Error generating lyrics:', error);
+      
+      // Handle different types of errors
+      if (error.response) {
+        // Axios error with response
+        console.error('Response error:', JSON.stringify(error.response.data));
+        
+        if (error.response.status === 402) {
+          return new NextResponse(JSON.stringify({ 
+            error: error.response.data?.detail || 'Payment required' 
+          }), {
+            status: 402,
+            headers: {
+              'Content-Type': 'application/json',
+              ...corsHeaders
+            }
+          });
+        }
+        
+        return new NextResponse(JSON.stringify({ 
+          error: 'API Error: ' + (error.response.data?.detail || error.response.statusText || 'Unknown error')
+        }), {
+          status: error.response.status || 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else if (error.request) {
+        // Axios error without response (network error, timeout, etc.)
+        console.error('Network error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Network error: Unable to connect to Suno API. Please check your internet connection and try again.' 
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else {
+        // Other types of errors (timeout, etc.)
+        console.error('Other error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Internal error: ' + (error.message || 'Unknown error occurred') 
+        }), {
+          status: 500,
           headers: {
             'Content-Type': 'application/json',
             ...corsHeaders
           }
         });
       }
-      return new NextResponse(JSON.stringify({ error: 'Internal server error: ' + JSON.stringify(error.response.data.detail) }), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
     }
   } else {
     return new NextResponse('Method Not Allowed', {

--- a/src/app/api/generate_stems/route.ts
+++ b/src/app/api/generate_stems/route.ts
@@ -32,23 +32,59 @@ export async function POST(req: NextRequest) {
         }
       });
     } catch (error: any) {
-      console.error('Error generating stems:', JSON.stringify(error.response.data));
-      if (error.response.status === 402) {
-        return new NextResponse(JSON.stringify({ error: error.response.data.detail }), {
-          status: 402,
+      console.error('Error generating stems:', error);
+      
+      // Handle different types of errors
+      if (error.response) {
+        // Axios error with response
+        console.error('Response error:', JSON.stringify(error.response.data));
+        
+        if (error.response.status === 402) {
+          return new NextResponse(JSON.stringify({ 
+            error: error.response.data?.detail || 'Payment required' 
+          }), {
+            status: 402,
+            headers: {
+              'Content-Type': 'application/json',
+              ...corsHeaders
+            }
+          });
+        }
+        
+        return new NextResponse(JSON.stringify({ 
+          error: 'API Error: ' + (error.response.data?.detail || error.response.statusText || 'Unknown error')
+        }), {
+          status: error.response.status || 500,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else if (error.request) {
+        // Axios error without response (network error, timeout, etc.)
+        console.error('Network error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Network error: Unable to connect to Suno API. Please check your internet connection and try again.' 
+        }), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            ...corsHeaders
+          }
+        });
+      } else {
+        // Other types of errors (timeout, etc.)
+        console.error('Other error:', error.message);
+        return new NextResponse(JSON.stringify({ 
+          error: 'Internal error: ' + (error.message || 'Unknown error occurred') 
+        }), {
+          status: 500,
           headers: {
             'Content-Type': 'application/json',
             ...corsHeaders
           }
         });
       }
-      return new NextResponse(JSON.stringify({ error: 'Internal server error: ' + JSON.stringify(error.response.data.detail) }), {
-        status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
     }
   } else {
     return new NextResponse('Method Not Allowed', {


### PR DESCRIPTION
- Fix TypeError crashes when requests timeout by adding proper error.response checks
- Improve error handling across all API routes: generate, generate_stems, extend_audio, generate_lyrics, concat
- Add better error messages for network errors, timeouts, and other failure scenarios
- Prevent crashes when error.response is undefined

Resolves 'Cannot read properties of undefined (reading data)' errors.